### PR TITLE
Fix pin relative path

### DIFF
--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -10,7 +10,7 @@ gnatcov = "^22.0.1"
 ada_spark_workflow = "~0.0.0"
 
 [[pins]]
-ada_spark_workflow = { path='../../ada_spark_workflow' }
+ada_spark_workflow = { path='..' }
 
 [build-profiles]
 ada_spark_workflow = "development"


### PR DESCRIPTION
This comes from the default behavior of `alr with --use ..`, which for some reason is botching the path (https://github.com/alire-project/alire/issues/1074)